### PR TITLE
Fix regular expression for syntax error detection

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -25,7 +25,7 @@ class Coffeelint(Linter):
     regex = (
         r'^<issue line="(?P<line>\d+)"\s*\r?\n'
         r'\s*lineEnd="\d+"\s*\r?\n'
-        r'\s*reason="\[(?:(?P<error>error)|(?P<warning>warn))\] (?P<message>.+?)"\s*\r?\n'
+        r'\s*reason="\[(?:(?P<error>error)|(?P<warning>warn))\](?: \[stdin\]:\d+:(?P<col>\d+): error:)? (?P<message>.+?)\r?\n'
     )
     multiline = True
     comment_re = r'\s*#'


### PR DESCRIPTION
coffeelint also can't detect syntax error, but the jslint xml reason attribute has other format:

**Normal lint error**

``` xml
<?xml version="1.0" encoding="utf-8"?><jslint>
<file name="stdin">
<issue line="39"
        lineEnd="39"
        reason="[error] Throwing strings is forbidden"
        evidence="undefined"/>
</file>
</jslint> 
```

**Syntax error**

``` xml
<?xml version="1.0" encoding="utf-8"?><jslint>
<file name="stdin">
<issue line="31"
        lineEnd="31"
        reason="[error] [stdin]:31:21: error: unmatched }
    gymkhana, number} = Session.get &apos;quiz&apos;
                    ^"
        evidence="undefined"/>
</file>
</jslint> 
```
