### PR TITLE
`--jslint` flag is now deprecated

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,7 @@ class Coffeelint(Linter):
     executable = 'coffeelint'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 1.0'
+    version_requirement = '>= 1.4'
     regex = (
         r'^<issue line="(?P<line>\d+)"\s*\r?\n'
         r'\s*lineEnd="\d+"\s*\r?\n'


### PR DESCRIPTION
As you can see [on this code](https://github.com/clutchski/coffeelint/blob/99804bd41409a0a5f90e3c89e933cce75c211b34/src/commandline.coffee#L165), the `--jslint` flag is now deprecated in favor of `--reporter=jslint`.
