### PR TITLE
Adds support for local coffeelint executable through NodeLinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --add-ignore=D202

--- a/linter.py
+++ b/linter.py
@@ -14,7 +14,6 @@ from SublimeLinter.lint import NodeLinter, persist
 
 
 class Coffeelint(NodeLinter):
-
     """Provides an interface to coffeelint."""
 
     npm_name = 'coffeelint'

--- a/linter.py
+++ b/linter.py
@@ -10,13 +10,14 @@
 
 """This module exports the Coffeelint plugin class."""
 
-from SublimeLinter.lint import Linter, persist
+from SublimeLinter.lint import NodeLinter, persist
 
 
-class Coffeelint(Linter):
+class Coffeelint(NodeLinter):
 
     """Provides an interface to coffeelint."""
 
+    npm_name = 'coffeelint'
     syntax = ('coffeescript', 'coffeescript_literate')
     executable = 'coffeelint'
     version_args = '--version'
@@ -36,7 +37,15 @@ class Coffeelint(Linter):
     def cmd(self):
         """Return a tuple with the command line to execute."""
 
-        command = [self.executable_path, '--reporter', 'jslint', '--stdin']
+        path = self.executable_path
+
+        if not path:
+            result = self.context_sensitive_executable_path([self.executable])
+
+            if result[1]:
+                path = result[1]
+
+        command = [path, '--reporter', 'jslint', '--stdin']
 
         if persist.get_syntax(self.view) == 'coffeescript_literate':
             command.append('--literate')


### PR DESCRIPTION
I've just integrated the NodeLinter class with this linter because I needed the ability to run a local version of coffeelint. I've tested it with both a local and a global version and it seems to work.
