### PR TITLE
Remove `npm_name` statement

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,6 @@ from SublimeLinter.lint import NodeLinter, util
 
 
 class Coffeelint(NodeLinter):
-    npm_name = 'coffeelint'
     regex = (
         r'^<issue line="(?P<line>\d+)"\s*\r?\n'
         r'\s*lineEnd="\d+"\s*\r?\n'


### PR DESCRIPTION
`SublimeLinter` gives the following error message for
`SublimeLinter-cofeelint`:

```
SublimeLinter: WARNING: coffeelint: Defining 'cls.npm_name' has no effect. Please cleanup and remove these settings.
```

This commit removes the `npm_name` statement.